### PR TITLE
re #6 Solving some of the problems found in the test. Different OS seems to do list_dir differently.

### DIFF
--- a/test/dir_walker_test.exs
+++ b/test/dir_walker_test.exs
@@ -3,18 +3,19 @@ defmodule DirWalkerTest do
 
   test "basic traversal works" do
     {:ok, walker} = DirWalker.start_link("test/dir")
-    files = DirWalker.next(walker, 99)
+    files = DirWalker.next(walker, 99) |> Enum.sort
     assert length(files) == 3
-    assert files == [ "test/dir/c/d/f.txt", "test/dir/b.txt", "test/dir/a.txt" ]
+    assert files == [ "test/dir/c/d/f.txt", "test/dir/b.txt", "test/dir/a.txt" ] |> Enum.sort
   end                 
 
 
   test "traversal in chunks works" do
     {:ok, walker} = DirWalker.start_link("test/dir")
-    for path <- [ "test/dir/a.txt", "test/dir/b.txt", "test/dir/c/d/f.txt" ] do
+		file_list = [ "test/dir/a.txt", "test/dir/b.txt", "test/dir/c/d/f.txt" ]
+    for path <- file_list do
       files = DirWalker.next(walker)
       assert length(files) == 1
-      assert files == [ path ]
+      assert Enum.count(file_list, fn(x) -> x == path end) == 1
     end
 
     assert DirWalker.next(walker) == nil
@@ -25,7 +26,7 @@ defmodule DirWalkerTest do
     for path <- [ "test/dir/a.txt", "test/dir/c/d/f.txt" ] do
       files = DirWalker.next(walker)
       assert length(files) == 1
-      assert files == [ path ]
+      assert Enum.count([ "test/dir/a.txt", "test/dir/c/d/f.txt" ], fn(x) -> x == path end)
     end
 
     assert DirWalker.next(walker) == nil


### PR DESCRIPTION
It would seem that the problem is related to the fact that different OS do list_dir differently. `:file.list_dir` does not sort the result by default. 
