### PR TITLE
Fix failure to filter directory names when :matching is specified.

### DIFF
--- a/test/dir_walker_test.exs
+++ b/test/dir_walker_test.exs
@@ -30,7 +30,18 @@ defmodule DirWalkerTest do
 
     assert DirWalker.next(walker) == nil
   end
-  
+
+  test "returns only matching names when also asking for directories" do
+    {:ok, walker} = DirWalker.start_link("test/dir", include_dir_names: true, matching: ~r(a|c|f))
+    for path <- [ "test/dir/a.txt", "test/dir/c", "test/dir/c/d", "test/dir/c/d/f.txt" ] do
+      files = DirWalker.next(walker)
+      assert length(files) == 1
+      assert files == [ path ]
+    end
+
+    assert DirWalker.next(walker) == nil
+  end
+
   test "returns stat if asked to" do
     {:ok, walker} = DirWalker.start_link("test/dir/c", include_stat: true)
     files = DirWalker.next(walker, 99)

--- a/test/dir_walker_test.exs
+++ b/test/dir_walker_test.exs
@@ -56,6 +56,13 @@ defmodule DirWalkerTest do
     assert  ["test/dir/c/d/f.txt", "test/dir/c/d"] = files
   end
 
+  test "directory names can be pulled one at a time" do
+    {:ok, walker} = DirWalker.start_link("test/dir/c/d", include_dir_names: true)
+    files = DirWalker.next(walker, 1)
+    assert length(files) == 1
+    assert  ["test/dir/c/d"] = files
+  end
+
   test "returns directory names and stats if asked to" do
     {:ok, walker} = DirWalker.start_link("test/dir/c/d", 
                                          include_stat:      true,


### PR DESCRIPTION
When both `:matching` and `:include_dir_names` are specified the directory names don't get filtered using the regex specified in the `:matching` option. We fix this by consolidating the path filtering into a single method, and use that to filter both the directory and regular file names. This actually ends up simplifying the `first_n/4` code.

A test is added to expose the bug, and to demonstrate that the fix works.
