### PR TITLE
matching option was matched on the whole path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DirWalker
 =========
 
-DirWalker lazily traverses one or more directory trees, depth first, 
+DirWalker lazily traverses one or more directory trees, depth first,
 returning successive file names.
 
 Initialize the walker using
@@ -13,9 +13,9 @@ Then return the next `n` path names using
     paths = DirWalker.next(walker [, n \\ 1])
 
 Successive calls to `next` will return successive file names, until
-all file names have been returned. 
+all file names have been returned.
 
-These methods have also been wrapped into a Stream resource. 
+These methods have also been wrapped into a Stream resource.
 
     paths = DirWalker.stream(path [, options]) # or [path,path...]
 
@@ -33,7 +33,7 @@ These methods have also been wrapped into a Stream resource.
   of regular files are returned). Note that the order is such that directory names
   will typically be returned after the names of files in those directories.
 
-* `matches: ` _regex_
+* `matching: ` _regex_
 
   Only file names matching the regex will be returned. Does not affect
   directory traversals.

--- a/lib/dir_walker.ex
+++ b/lib/dir_walker.ex
@@ -7,7 +7,7 @@ defmodule DirWalker do
   use GenServer
 
   def start_link(path, opts \\ %{})
- 
+
   def start_link(list_of_paths, opts) when is_list(list_of_paths) do
     mappers = setup_mappers(opts)
     GenServer.start_link(__MODULE__, {list_of_paths, mappers})
@@ -27,7 +27,7 @@ defmodule DirWalker do
 
         iex> {:ok,d} = DirWalker.start_link "."
         {:ok, #PID<0.83.0>}
-        iex> DirWalker.next(d)                 
+        iex> DirWalker.next(d)
         ["./.gitignore"]
         iex> DirWalker.next(d)
         ["./_build/dev/lib/dir_walter/.compile.elixir"]
@@ -35,7 +35,7 @@ defmodule DirWalker do
         ["./_build/dev/lib/dir_walter/ebin/Elixir.DirWalker.beam",
          "./_build/dev/lib/dir_walter/ebin/dir_walter.app",
          "./_build/dev/lib/dir_walter/.compile.lock"]
-        iex> 
+        iex>
   """
   def next(iterator, n \\ 1) do
     GenServer.call(iterator, { :get_next, n })
@@ -49,7 +49,7 @@ defmodule DirWalker do
   end
 
   @doc """
-  Implement a stream interface that will return a lazy enumerable. 
+  Implement a stream interface that will return a lazy enumerable.
 
   ## Example
 
@@ -58,19 +58,19 @@ defmodule DirWalker do
   """
 
   def stream(path_list) do
-    Stream.resource( fn -> 
-                      {:ok, dirw} = DirWalker.start_link(path_list) 
+    Stream.resource( fn ->
+                      {:ok, dirw} = DirWalker.start_link(path_list)
                       dirw
                     end ,
-                    fn(dirw) -> 
+                    fn(dirw) ->
                       case DirWalker.next(dirw,1) do
                         data when is_list(data) -> {data, dirw }
                         _ -> {:halt, dirw}
                       end
                     end,
-                    fn(dirw) -> DirWalker.stop(dirw) end 
+                    fn(dirw) -> DirWalker.stop(dirw) end
       )
-  end 
+  end
 
   ##################
   # Implementation #
@@ -91,18 +91,18 @@ defmodule DirWalker do
   end
 
 
-  # If the first element is a list, then it represents a 
+  # If the first element is a list, then it represents a
   # nested directory listing. We keep it as a list rather
   # than flatten it in order to keep performance up.
 
   defp first_n([ [] | rest ], n, mappers, result)  do
     first_n(rest, n, mappers, result)
   end
-      
+
   defp first_n([ [first] | rest ], n, mappers, result)  do
     first_n([ first | rest ], n, mappers, result)
   end
-      
+
   defp first_n([ [first | nested] | rest ], n, mappers, result)  do
     first_n([ first | [ nested | rest ] ], n, mappers, result)
   end
@@ -116,13 +116,13 @@ defmodule DirWalker do
     stat = File.stat!(path)
     case stat.type do
     :directory ->
-      first_n([files_in(path) | rest], 
-              n, 
-              mappers, 
+      first_n([files_in(path) | rest],
+              n,
+              mappers,
               mappers.include_dir_names.(mappers.include_stat.(path, stat), result))
 
     :regular ->
-        if mappers.matching.(path) do
+        if mappers.matching.(Path.basename(path)) do
         first_n(rest, n-1, mappers, [ mappers.include_stat.(path, stat) | result ])
       else
         first_n(rest, n, mappers, result)
@@ -152,12 +152,12 @@ defmodule DirWalker do
     %{
       include_stat:
         one_of(opts[:include_stat],
-               fn (path, _stat) -> path end,    
+               fn (path, _stat) -> path end,
                fn (path, stat)  -> {path, stat} end),
 
       include_dir_names:
         one_of(opts[:include_dir_names],
-               fn (_path, result) -> result end,    
+               fn (_path, result) -> result end,
                fn (path, result)  -> [ path | result ] end),
       matching:
         one_of(!!opts[:matching],

--- a/test/dir_walker_test.exs
+++ b/test/dir_walker_test.exs
@@ -31,6 +31,19 @@ defmodule DirWalkerTest do
     assert DirWalker.next(walker) == nil
   end
 
+  test "returns nil after consuming one only file with matching name out of many" do
+    {:ok, walker} = DirWalker.start_link("test/dir", matching: ~r(^a\.txt$))
+    [ "test/dir/a.txt"] = DirWalker.next(walker)
+    assert DirWalker.next(walker) == nil
+  end
+
+  test "returns nil after consuming one only file with matching name out of one" do
+    {:ok, walker} = DirWalker.start_link("test/dir/c/d", matching: ~r(^f\.txt$))
+    [ "test/dir/c/d/f.txt"] = DirWalker.next(walker)
+    assert DirWalker.next(walker) == nil
+  end
+
+
   test "returns stat if asked to" do
     {:ok, walker} = DirWalker.start_link("test/dir/c", include_stat: true)
     files = DirWalker.next(walker, 99)

--- a/test/dir_walker_test.exs
+++ b/test/dir_walker_test.exs
@@ -6,7 +6,7 @@ defmodule DirWalkerTest do
     files = DirWalker.next(walker, 99)
     assert length(files) == 3
     assert files == [ "test/dir/c/d/f.txt", "test/dir/b.txt", "test/dir/a.txt" ]
-  end                 
+  end
 
 
   test "traversal in chunks works" do
@@ -18,10 +18,10 @@ defmodule DirWalkerTest do
     end
 
     assert DirWalker.next(walker) == nil
-  end     
+  end
 
   test "returns only matching names if requested" do
-    {:ok, walker} = DirWalker.start_link("test/dir", matching: ~r(a|f))
+    {:ok, walker} = DirWalker.start_link("test/dir", matching: ~r(^a|f))
     for path <- [ "test/dir/a.txt", "test/dir/c/d/f.txt" ] do
       files = DirWalker.next(walker)
       assert length(files) == 1
@@ -30,7 +30,7 @@ defmodule DirWalkerTest do
 
     assert DirWalker.next(walker) == nil
   end
-  
+
   test "returns stat if asked to" do
     {:ok, walker} = DirWalker.start_link("test/dir/c", include_stat: true)
     files = DirWalker.next(walker, 99)
@@ -46,35 +46,35 @@ defmodule DirWalkerTest do
   end
 
   test "returns directory names and stats if asked to" do
-    {:ok, walker} = DirWalker.start_link("test/dir/c/d", 
+    {:ok, walker} = DirWalker.start_link("test/dir/c/d",
                                          include_stat:      true,
                                          include_dir_names: true)
     files = DirWalker.next(walker, 99)
     assert length(files) == 2
-    assert  [{"test/dir/c/d/f.txt", s1 = %File.Stat{}}, 
+    assert  [{"test/dir/c/d/f.txt", s1 = %File.Stat{}},
              {"test/dir/c/d",       s3 = %File.Stat{}}] = files
     assert s1.type == :regular
     assert s3.type == :directory
   end
 
-  test "stop method works" do 
+  test "stop method works" do
    {:ok, walker} = DirWalker.start_link("test/dir")
-   assert DirWalker.stop(walker) == :ok 
+   assert DirWalker.stop(walker) == :ok
    refute Process.alive?(walker)
-  end             
+  end
 
   test "stream method works" do
-      dirw = DirWalker.stream("test/dir") 
+      dirw = DirWalker.stream("test/dir")
       file =  Enum.take(dirw,1)
       assert length(file) == 1
-      assert file == [ "test/dir/a.txt"] 
-  end 
+      assert file == [ "test/dir/a.txt"]
+  end
 
-  test "stream method completes" do 
+  test "stream method completes" do
      paths = [ "test/dir/a.txt", "test/dir/b.txt", "test/dir/c/d/f.txt" ]
      dirw = DirWalker.stream("test/dir")
      files = Enum.into(dirw,[])
      assert Enum.sort(files) == Enum.sort(paths)
-  end 
+  end
 
 end


### PR DESCRIPTION
The doc says (and makes sense imho) to match the file name instead. The test case was passing because the regex was not using anchors.

Updated the doc that was naming wrong key "matches" instead of "matching". 
Updated tests.

Sorry for the whitespace cleanup, got the editor setup that way.
